### PR TITLE
Add Radio input

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "cSpell.words": ["clsx"],
-  "editor.wordWrap": "bounded",
+  "editor.wordWrap": "on",
   "tailwindCSS.experimental.classRegex": ["'@apply ([^']+)'"]
 }

--- a/packages/core/components/checkbox.css
+++ b/packages/core/components/checkbox.css
@@ -2,31 +2,36 @@
   @apply form-checkbox rounded border border-primary-pure text-primary-pure hover:ring-4 hover:ring-high-light focus:ring-2 focus:ring-primary-lighter focus:ring-offset-2 active:bg-high-medium active:ring-high-dark checked:active:bg-primary-pure disabled:border-high-dark disabled:text-high-dark;
 
   & + span,
+  & + label,
   & + .checkbox-label {
     @apply ml-3 text-low-dark;
   }
 
   &:checked + span,
+  &:checked + label,
   &:checked + .checkbox-label {
     @apply text-black;
+  }
+
+  &:disabled + span,
+  &:disabled + label,
+  &:disabled + .checkbox-label {
+    @apply text-high-dark;
   }
 
   &-error {
     @apply border-error-pure text-error-pure checked:active:bg-error-pure;
 
     & + span,
+    & + label,
     & + .checkbox-label {
       @apply text-error-pure;
     }
 
     &:checked + span,
+    &:checked + label,
     &:checked + .checkbox-label {
       @apply text-error-pure;
     }
-  }
-
-  &:disabled + span,
-  &:disabled + .checkbox-label {
-    @apply text-high-dark;
   }
 }

--- a/packages/core/components/index.css
+++ b/packages/core/components/index.css
@@ -2,3 +2,4 @@
 @import './avatar.css';
 @import './badge.css';
 @import './checkbox.css';
+@import './radio.css';

--- a/packages/core/components/radio.css
+++ b/packages/core/components/radio.css
@@ -1,0 +1,21 @@
+.radio {
+  @apply form-radio border-primary-pure text-primary-pure hover:ring-4 hover:ring-high-light focus:outline-none focus:ring-2 focus:ring-primary-lighter focus:ring-offset-2 active:bg-high-medium active:ring-high-dark disabled:border-high-dark;
+
+  & + span,
+  & + label,
+  & + .radio-label {
+    @apply ml-3 text-low-dark;
+  }
+
+  &:disabled + span,
+  &:disabled + label,
+  &:disabled + .radio-label {
+    @apply text-high-dark;
+  }
+
+  &:checked + span,
+  &:checked + label,
+  &:checked + .radio-label {
+    @apply text-black;
+  }
+}

--- a/packages/storybook/stories/components/checkbox/checkbox.stories.js
+++ b/packages/storybook/stories/components/checkbox/checkbox.stories.js
@@ -6,7 +6,7 @@ export default {
     docs: {
       description: {
         component:
-          'To use the checkbox component, add the `checkbox` class to the `input` element.<br>For the label, you can either use a `span` tag or apply the `.checkbox-label` class to another element.<br>Base class: `.checkbox`. States: `.checkbox-{error}`.',
+          'To use the checkbox component, add the `.checkbox` class to the `input` element.<br>For the label, you can either use a `span` or `label` tag or apply the `.checkbox-label` class to another element.<br>Base class: `.checkbox`. States: `.checkbox-{error}`.',
       },
     },
   },
@@ -54,8 +54,8 @@ export const Default = args => createCheckbox(args);
  * To use another element as the checkbox input label, add the `.checkbox-label` class to it and the element will inherit the styles.
  */
 export const CustomLabel = () => `
-<div class="inline-flex items-center">
+<label class="inline-flex items-center">
   <input id="checkbox" type="checkbox" class="checkbox" />
-  <label for="checkbox" class="checkbox-label">Checkbox</label>
-</div>
+  <div class="checkbox-label">I'm a &lt;div/&gt;</div>
+</label>
 `;

--- a/packages/storybook/stories/components/radio/create-radio.js
+++ b/packages/storybook/stories/components/radio/create-radio.js
@@ -1,0 +1,20 @@
+import clsx from 'clsx';
+
+export function createRadio({ isDisabled }) {
+  return `
+    <div class="flex gap-3">
+      <label class="inline-flex items-center">
+        <input id="superman" name="radio" type="radio" class="${clsx(
+          'radio',
+        )}"${isDisabled ? ' disabled' : ''} />
+        <span>Superman</span>
+      </label>
+      <div class="inline-flex items-center">
+        <input id="batman" name="radio" type="radio" class="${clsx('radio')}"${
+    isDisabled ? ' disabled' : ''
+  } />
+        <label for="batman">Batman</label>
+      </div>
+    </div>
+  `;
+}

--- a/packages/storybook/stories/components/radio/radio.stories.js
+++ b/packages/storybook/stories/components/radio/radio.stories.js
@@ -1,0 +1,37 @@
+import { createRadio } from './create-radio';
+
+export default {
+  title: 'Components/Radio',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'To use the radio component, add the `.radio` class to the `input` element.<br>For the label, you can either use a `span` or `label` tag or apply the `.radio-label` class to another element.<br>Base class: `.radio`',
+      },
+    },
+  },
+  args: {
+    isDisabled: false,
+  },
+  argTypes: {
+    isDisabled: {
+      description:
+        'Disables the radio input.<br><br>Use the `disabled` attribute.',
+      table: {
+        defaultValue: { summary: false },
+      },
+    },
+  },
+};
+
+export const Radio = args => createRadio(args);
+
+/**
+ * To use another element as the radio input label, add the `.radio-label` class to it and the element will inherit the styles.
+ */
+export const CustomLabel = () => `
+<label class="inline-flex items-center">
+  <input id="radio" type="radio" class="radio" />
+  <div class="radio-label">I'm a &lt;div/&gt;</div>
+</label>
+`;


### PR DESCRIPTION
- Adds the Radio input component to the Design System
- Uses @tailwindcss/forms to reset the styles from the native radio input
- Fixes some information on the Checkbox docs