### PR TITLE
Add the input and input-group components

### DIFF
--- a/packages/core/components/index.css
+++ b/packages/core/components/index.css
@@ -3,3 +3,5 @@
 @import './badge.css';
 @import './checkbox.css';
 @import './radio.css';
+@import './input.css';
+@import './input-group.css';

--- a/packages/core/components/input-group.css
+++ b/packages/core/components/input-group.css
@@ -1,0 +1,96 @@
+.input-group {
+  @apply relative flex items-center gap-2 rounded border border-low-light px-4 text-sm font-medium leading-none text-black placeholder:text-low-medium focus-within:border-primary-light focus-within:ring-2 focus-within:ring-primary-light;
+
+  .input {
+    @apply border-none px-0 focus:ring-0;
+  }
+  .input:invalid,
+  .input.input-invalid {
+    @apply ring-0;
+  }
+
+  .input-group-icon {
+    @apply flex items-center text-low-dark;
+  }
+
+  .input ~ label,
+  .input ~ span,
+  .input ~ .input-label {
+    @apply left-0;
+  }
+
+  &-md {
+    @apply text-base;
+    .input {
+      @apply py-4;
+    }
+    .input ~ label,
+    .input ~ span,
+    .input ~ .input-label {
+      @apply -translate-y-2.5;
+    }
+    .input:placeholder-shown ~ label,
+    .input:placeholder-shown ~ span,
+    .input:placeholder-shown ~ .input-label {
+      @apply translate-y-[1.125rem];
+    }
+    /* The :focus selector must have priority over :placeholder-shown */
+    .input:focus ~ label,
+    .input:focus ~ span,
+    .input:focus ~ .input-label {
+      @apply -translate-y-2.5;
+    }
+  }
+  &-lg {
+    @apply text-lg;
+    .input {
+      @apply py-5;
+    }
+    .input ~ label,
+    .input ~ span,
+    .input ~ .input-label {
+      @apply -translate-y-2.5;
+    }
+    .input:placeholder-shown ~ label,
+    .input:placeholder-shown ~ span,
+    .input:placeholder-shown ~ .input-label {
+      @apply translate-y-[1.4rem];
+    }
+    /* The :focus selector must have priority over :placeholder-shown */
+    .input:focus ~ label,
+    .input:focus ~ span,
+    .input:focus ~ .input-label {
+      @apply -translate-y-2.5;
+    }
+  }
+
+  &.input-group-invalid:not(.input-group-disabled) {
+    @apply border-error-pure ring-2 ring-error-pure;
+
+    .input-group-icon.inherit-color {
+      @apply fill-error-pure text-error-pure;
+    }
+  }
+
+  &.input-group-disabled {
+    @apply border-high-dark text-high-dark;
+
+    .input {
+      @apply placeholder:text-high-dark;
+    }
+
+    .input-group-icon {
+      @apply fill-high-dark text-high-dark;
+    }
+  }
+}
+.input-group.input-group-invalid:not(.input-group-disabled)
+  + .input-group-alt.input-group-alt {
+  @apply text-error-pure;
+}
+.input-group.input-group-disabled + .input-group-alt {
+  @apply text-high-dark;
+}
+.input-group-alt {
+  @apply ml-4 mt-1 block text-2xs font-medium leading-normal;
+}

--- a/packages/core/components/input.css
+++ b/packages/core/components/input.css
@@ -40,28 +40,34 @@
 
 .input.input-md ~ span,
 .input.input-md ~ label,
-.input.input-md ~ .input-label,
+.input.input-md ~ .input-label {
+  @apply -translate-y-2;
+}
+.input.input-md:placeholder-shown ~ .input-label,
+.input.input-md:placeholder-shown ~ label,
+.input.input-md:placeholder-shown ~ span {
+  @apply translate-y-[1.15rem];
+}
+/* The :focus selector must have priority over the :placeholder-shown */
 .input.input-md:focus ~ span,
 .input.input-md:focus ~ label,
 .input.input-md:focus ~ .input-label {
   @apply -translate-y-2;
 }
-.input-md:placeholder-shown ~ .input-label,
-.input-md:placeholder-shown ~ label,
-.input-md:placeholder-shown ~ span {
-  @apply translate-y-[1.15rem];
-}
 
 .input.input-lg ~ .input-label,
 .input.input-lg ~ label,
-.input.input-lg ~ span,
-.input.input-lg:focus ~ .input-label,
-.input.input-lg:focus ~ label,
-.input.input-lg:focus ~ span {
+.input.input-lg ~ span {
   @apply -translate-y-2;
 }
 .input-lg:placeholder-shown ~ .input-label,
 .input-lg:placeholder-shown ~ label,
 .input-lg:placeholder-shown ~ span {
   @apply translate-y-[1.4rem];
+}
+/* The :focus selector must have priority over the :placeholder-shown */
+.input.input-lg:focus ~ span,
+.input.input-lg:focus ~ label,
+.input.input-lg:focus ~ .input-label {
+  @apply -translate-y-2;
 }

--- a/packages/core/components/input.css
+++ b/packages/core/components/input.css
@@ -1,0 +1,67 @@
+.input {
+  @apply form-input rounded border-low-light px-4 text-sm font-medium leading-none text-black placeholder:text-low-medium focus:border-primary-light focus:ring-2 focus:ring-primary-light disabled:border-high-dark disabled:text-high-dark disabled:placeholder:text-high-dark;
+
+  &:invalid:not(:disabled),
+  &.input-invalid:not(:disabled) {
+    @apply border-error-pure ring-2 ring-error-pure;
+  }
+
+  &-md {
+    @apply py-4;
+  }
+  &-lg {
+    @apply py-5;
+  }
+}
+
+.input ~ .input-label,
+.input ~ label,
+.input ~ span {
+  @apply pointer-events-none absolute top-0 left-3.5 z-10 origin-[0] -translate-y-2 scale-75 bg-white px-1 text-sm font-medium leading-none text-low-dark transition-transform duration-300 ease-out;
+}
+
+.input:placeholder-shown ~ .input-label,
+.input:placeholder-shown ~ label,
+.input:placeholder-shown ~ span {
+  @apply translate-y-2.5 scale-100;
+}
+
+.input:focus ~ .input-label,
+.input:focus ~ label,
+.input:focus ~ span {
+  @apply top-0 -translate-y-2 scale-75 px-1;
+}
+
+.input:disabled ~ .input-label,
+.input:disabled ~ label,
+.input:disabled ~ span {
+  @apply text-high-dark;
+}
+
+.input.input-md ~ span,
+.input.input-md ~ label,
+.input.input-md ~ .input-label,
+.input.input-md:focus ~ span,
+.input.input-md:focus ~ label,
+.input.input-md:focus ~ .input-label {
+  @apply -translate-y-2;
+}
+.input-md:placeholder-shown ~ .input-label,
+.input-md:placeholder-shown ~ label,
+.input-md:placeholder-shown ~ span {
+  @apply translate-y-[1.15rem];
+}
+
+.input.input-lg ~ .input-label,
+.input.input-lg ~ label,
+.input.input-lg ~ span,
+.input.input-lg:focus ~ .input-label,
+.input.input-lg:focus ~ label,
+.input.input-lg:focus ~ span {
+  @apply -translate-y-2;
+}
+.input-lg:placeholder-shown ~ .input-label,
+.input-lg:placeholder-shown ~ label,
+.input-lg:placeholder-shown ~ span {
+  @apply translate-y-[1.4rem];
+}

--- a/packages/storybook/stories/components/input-group/create-input-group.js
+++ b/packages/storybook/stories/components/input-group/create-input-group.js
@@ -1,0 +1,80 @@
+import clsx from 'clsx';
+
+const sizes = {
+  small: '',
+  medium: 'input-group-md',
+  large: 'input-group-lg',
+};
+
+export function createInputGroup({ size, isInvalid, isDisabled }) {
+  return `
+  <div>
+    <div class="${clsx(
+      'input-group',
+      sizes[size],
+      isInvalid && 'input-group-invalid',
+      isDisabled && 'input-group-disabled',
+    )}">
+      <div class="input-group-icon">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          width="1em"
+          height="1em"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+          />
+        </svg>
+      </div>
+
+      <div class="block relative w-full">
+        <input id="id" type="text" class="input" placeholder=" "${
+          isDisabled ? ' disabled' : ''
+        } />
+        <label for="id">Floating label</label>
+      </div>
+
+      <!-- OR -->
+      <!-- <label for="id" class="block relative w-full">
+        <input id="id" type="text" class="input" placeholder=" "${
+          isDisabled ? ' disabled' : ''
+        } />
+        <span>Floating label</span>
+      </label> -->
+
+      <!-- OR -->
+      <!-- <label for="id" class="block relative w-full">
+        <input id="id" type="text" class="input" placeholder=" "${
+          isDisabled ? ' disabled' : ''
+        } />
+        <div class="input-label">Floating label</div>
+      </label> -->
+
+      <div class="input-group-icon inherit-color">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          width="1em"
+          height="1em"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M6 18L18 6M6 6l12 12"
+          />
+        </svg>
+      </div>
+    </div>
+    <span class="input-group-alt">Helper text</span>
+  </div>
+  `;
+}

--- a/packages/storybook/stories/components/input-group/input-group.stories.js
+++ b/packages/storybook/stories/components/input-group/input-group.stories.js
@@ -1,0 +1,37 @@
+import { createInputGroup } from './create-input-group.js';
+
+export default {
+  title: 'Components/Input Group',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Use input groups to add icons to an input.<br><strong>Important:</strong> Since this is not a JavaScript library, we can't make the input group automatically receive the `.input-group-invalid` or `.input-group-disabled` whenever the actual input is invalid or disabled.<br>You will need to add the `.input-group-invalid` or `.input-group-disabled` class to the input group wrapper manually.",
+      },
+    },
+  },
+  args: { size: 'small', isInvalid: false, isDisabled: false },
+  argTypes: {
+    size: {
+      options: ['small', 'medium', 'large'],
+      control: { type: 'radio' },
+      table: { defaultValue: { summary: 'small' } },
+      description:
+        'Set the input-group size.<br>Class: `.input-group-{md|lg}`.',
+    },
+    isInvalid: {
+      table: { defaultValue: { summary: 'false' } },
+      control: { type: 'boolean' },
+      description:
+        'Set the input-group to invalid state.<br>Targets the `.input-group-invalid` class.',
+    },
+    isDisabled: {
+      table: { defaultValue: { summary: 'false' } },
+      control: { type: 'boolean' },
+      description:
+        'Set the input-group to disabled state.<br>Targets the `.input-group-disabled` class.',
+    },
+  },
+};
+
+export const InputGroup = args => createInputGroup(args);

--- a/packages/storybook/stories/components/input/input.stories.js
+++ b/packages/storybook/stories/components/input/input.stories.js
@@ -1,0 +1,59 @@
+import clsx from 'clsx';
+
+export default {
+  title: 'Components/Input',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '<strong>Important:</strong> Make sure to follow the example markup structure to ensure proper styling and behavior. More specifically, the `label`, `span` or `.input-label` element must come immediately after the `input` and the `placeholder` content must be set to a single space.',
+      },
+    },
+  },
+  args: { size: 'small', isInvalid: false, isDisabled: false },
+  argTypes: {
+    size: {
+      options: ['small', 'medium', 'large'],
+      control: { type: 'radio' },
+      table: { defaultValue: { summary: 'small' } },
+      description: 'Set input size.<br>Class: `.input-{md|lg}`.',
+    },
+    isInvalid: {
+      table: { defaultValue: { summary: 'false' } },
+      control: { type: 'boolean' },
+      description:
+        'Set input to invalid state.<br>Targets the `:invalid` pseudo-class or the `.input-invalid` class.',
+    },
+    isDisabled: {
+      table: { defaultValue: { summary: 'false' } },
+      control: { type: 'boolean' },
+      description:
+        'Set input to disabled state.<br>Targets the `:disabled` pseudo-class or the `.input-disabled` class.',
+    },
+  },
+};
+
+export const Default = args => `
+  <div class="block relative">
+    <input id="email" type="email" class="${clsx('input', {
+      'input-invalid': args.isInvalid,
+      'input-md': args.size === 'medium',
+      'input-lg': args.size === 'large',
+    })}" placeholder=" "${args.isDisabled ? ' disabled' : ''} />
+    <label for="email">E-mail</label>
+  </div>
+`;
+
+export const WithLabelWrapper = () => `
+  <label for="email" class="block relative">
+    <input id="email" type="email" class="input" placeholder=" " />
+    <span>E-mail</span>
+  </label>
+`;
+
+export const WithCustomLabelElement = () => `
+  <label for="email" class="block relative">
+    <input id="email" type="email" class="input" placeholder=" " />
+    <p class="input-label">E-mail</p>
+  </label>
+`;

--- a/packages/storybook/stories/components/input/input.stories.js
+++ b/packages/storybook/stories/components/input/input.stories.js
@@ -42,18 +42,24 @@ export const Default = args => `
     })}" placeholder=" "${args.isDisabled ? ' disabled' : ''} />
     <label for="email">E-mail</label>
   </div>
-`;
 
-export const WithLabelWrapper = () => `
-  <label for="email" class="block relative">
-    <input id="email" type="email" class="input" placeholder=" " />
+  <!-- OR -->
+  <!-- <label for="email" class="block relative">
+    <input id="email" type="email" class="${clsx('input', {
+      'input-invalid': args.isInvalid,
+      'input-md': args.size === 'medium',
+      'input-lg': args.size === 'large',
+    })}" placeholder=" "${args.isDisabled ? ' disabled' : ''} />
     <span>E-mail</span>
-  </label>
-`;
+  </label> -->
 
-export const WithCustomLabelElement = () => `
-  <label for="email" class="block relative">
-    <input id="email" type="email" class="input" placeholder=" " />
-    <p class="input-label">E-mail</p>
-  </label>
+  <!-- OR -->
+  <!-- <label for="email" class="block relative">
+    <input id="email" type="email" class="${clsx('input', {
+      'input-invalid': args.isInvalid,
+      'input-md': args.size === 'medium',
+      'input-lg': args.size === 'large',
+    })}" placeholder=" "${args.isDisabled ? ' disabled' : ''} />
+    <div class="input-label">E-mail</div>
+  </label> -->
 `;


### PR DESCRIPTION
# Input Component

Adds the `input` and `input-group` components to the Design System.

## Input
- Base: `.input`
- Sizes: `.input-{md|lg}`
- States: `{:invalid|.input-invalid}`, `:disabled`

## Input Group
- Base: `.input-group`
- Sizes: `.input-group-{md|lg}`
- States: `.input-group-{invalid|disabled}` 
- Children: `.input-group-icon`